### PR TITLE
Parameterize SQL queries to use recommended method

### DIFF
--- a/RochesterSurvey.php
+++ b/RochesterSurvey.php
@@ -16,9 +16,8 @@ class RochesterSurvey extends \ExternalModules\AbstractExternalModule {
 		$settings = json_decode($settings, true);
 		$edoc_id = $settings['endOfSurveyImage'];
 		if (!empty($edoc_id)) {
-			$sql = "SELECT * FROM redcap_edocs_metadata WHERE doc_id=$edoc_id";
-			$result = db_query($sql);
-			if ($row = db_fetch_assoc($result)) {
+			$result = $this->framework->query("SELECT * FROM redcap_edocs_metadata WHERE doc_id=?", [$edoc_id]);
+			if ($row = $result->fetch_assoc()) {
 				$encodedImage = base64_encode(file_get_contents(EDOC_PATH . $row["stored_name"]));
 				$imgSrc = "data: {$row["mime_type"]};base64,$encodedImage";
 				$img = "<img src=\'$imgSrc\'>";

--- a/RochesterSurvey.php
+++ b/RochesterSurvey.php
@@ -139,9 +139,8 @@ class RochesterSurvey extends \ExternalModules\AbstractExternalModule {
 			// delete old image if possible
 			$old_edoc_id = $settings['endOfSurveyImage'];
 			if (!empty($old_edoc_id)) {
-				$sql = "SELECT * FROM redcap_edocs_metadata WHERE doc_id=$old_edoc_id";
-				$result = db_query($sql);
-				while ($row = db_fetch_assoc($result)) {
+				$result = $this->framework->query("SELECT * FROM redcap_edocs_metadata WHERE doc_id=?", [$old_edoc_id]);
+				while ($row = $result->fetch_assoc()) {
 					unlink(EDOC_PATH . $row["stored_name"]);
 				}
 			}

--- a/RochesterSurvey.php
+++ b/RochesterSurvey.php
@@ -353,9 +353,8 @@ class RochesterSurvey extends \ExternalModules\AbstractExternalModule {
 		$delete_button = null;
 		$edoc_id = (int) $settings['endOfSurveyImage'];
 		if (!empty($edoc_id)) {
-			$sql = "SELECT * FROM redcap_edocs_metadata WHERE doc_id=$edoc_id";
-			$result = db_query($sql);
-			if ($row = db_fetch_assoc($result)) {
+			$result = $this->framework->query("SELECT * FROM redcap_edocs_metadata WHERE doc_id=?", [$edoc_id]);
+			if ($row = $result->fetch_assoc()) {
 				$encodedImage = base64_encode(file_get_contents(EDOC_PATH . $row["stored_name"]));
 				$imgSrc = "data: {$row["mime_type"]};base64,$encodedImage";
 				$img = "<img src='$imgSrc'>";

--- a/video_config_ajax.php
+++ b/video_config_ajax.php
@@ -154,9 +154,8 @@ if ($action == 'image_delete') {
 	$module->setProjectSetting($form_name, json_encode($settings));
 		
 	// remove old edoc file
-	$sql = "SELECT * FROM redcap_edocs_metadata WHERE doc_id=$old_edoc_id";
-	$result = db_query($sql);
-	while ($row = db_fetch_assoc($result)) {
+	$result = $module->query("SELECT * FROM redcap_edocs_metadata WHERE doc_id=?", [$old_edoc_id]);
+	while ($row = $result->fetch_assoc()) {
 		unlink(EDOC_PATH . $row["stored_name"]);
 	}
 }

--- a/video_config_ajax.php
+++ b/video_config_ajax.php
@@ -119,9 +119,8 @@ if (!empty($_FILES['image'])) {
 		$new_edoc_id = $module->set_end_of_survey_image($form_name, $file['tmp_name']);
 		
 		// send back image
-		$sql = "SELECT * FROM redcap_edocs_metadata WHERE doc_id=$new_edoc_id";
-		$result = db_query($sql);
-		while ($row = db_fetch_assoc($result)) {
+		$result = $module->query("SELECT * FROM redcap_edocs_metadata WHERE doc_id=?", [$new_edoc_id]);
+		while ($row = $result->fetch_assoc()) {
 			$uri = base64_encode(file_get_contents(EDOC_PATH . $row["stored_name"]));
 			$iconSrc = "data: {$row["mime_type"]};base64,$uri";
 			$imgElement = "<img src='$iconSrc' class='logo-image'>";


### PR DESCRIPTION
Hi @carlreedw ,

The Utah BMIC team wants to use the rochester-survey for one of our client's projects. We run a security review for all modules enabled on our system and found that the module uses appended strings for its SQL queries. I went ahead and modified the SQL queries to use the recommended `$module->query()` method as described in the EM framework documentation (https://github.com/vanderbilt-redcap/external-module-framework/blob/testing/docs/querying.md). Hopefully I caught all of the SQL queries? Testing on my end shows that everything still works.

I didn't think this required updating the framework version in `config.json` so I kept that as is.

Please let me know if there are further changes you would like made.

Thanks for your work on this!!